### PR TITLE
fix(settings): load AWS secrets before initializing Django settings

### DIFF
--- a/feedit_app/app/settings.py
+++ b/feedit_app/app/settings.py
@@ -12,6 +12,9 @@ import os
 from pathlib import Path
 
 import environ
+from app.settings_loader import load_secrets
+
+load_secrets()  # ✅ Load AWS secrets before using env() - production only
 
 # Initialize environ first
 env = environ.Env(DEBUG=(bool, False))

--- a/feedit_app/app/settings_loader.py
+++ b/feedit_app/app/settings_loader.py
@@ -1,0 +1,22 @@
+import json
+import os
+import boto3
+
+
+def load_secrets():
+    if os.getenv("DJANGO_ENV") != "production":
+        return
+
+    secret_name = os.getenv("DJANGO_AWS_SECRET_NAME")
+    region_name = os.getenv("AWS_REGION", "eu-north-1")
+
+    if not secret_name:
+        raise Exception("DJANGO_AWS_SECRET_NAME not set")
+
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager", region_name=region_name)
+    get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+    secrets = json.loads(get_secret_value_response["SecretString"])
+
+    for key, value in secrets.items():
+        os.environ.setdefault(key, value)  # only sets if not already present


### PR DESCRIPTION
Move AWS Secrets Manager loading into settings_loader.py and call it at the top of settings.py. This ensures all required environment variables (e.g. DB_NAME, S3 config) are available before environ.Env() is initialized, fixing S3 integration and manage.py shell failures.