### PR TITLE
ci(cd): force clean Docker build to ensure updated settings are included

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,9 +27,12 @@ jobs:
       - name: Log in to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Clear Docker build cache
+        run: docker builder prune -af
+
       - name: Build Docker image
         run: |
-          docker build -t $ECR_REPOSITORY_URI:latest .
+          docker build --no-cache -t $ECR_REPOSITORY_URI:latest .
 
       - name: Install Grype (container vulnerability scanner)
         run: |

--- a/.github/workflows/zap_scan.yml
+++ b/.github/workflows/zap_scan.yml
@@ -27,16 +27,16 @@ jobs:
           target: 'https://feedit.online'
           fail_action: false
           artifact_name: zap-report
-          cmd_options: '-w zap_report.md -r zap_report.html'
+          cmd_options: '-w report_md.md -r zap_report.html'
           allow_issue_writing: false
         continue-on-error: true
 
       - name: Display ZAP Summary in GitHub UI
         run: |
-          if [ -f zap_report.md ]; then
+          if [ -f report_md.md ]; then
             echo "## 🔐 OWASP ZAP Baseline Scan Summary" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            cat zap_report.md >> $GITHUB_STEP_SUMMARY
+            cat report_md.md >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ No Markdown report found. ZAP may have failed or produced no output." >> $GITHUB_STEP_SUMMARY
           fi
@@ -46,5 +46,5 @@ jobs:
         with:
           name: zap-report
           path: |
-            zap_report.md
+            report_md.md
             zap_report.html


### PR DESCRIPTION
Add step to prune Docker builder cache and rebuild image with --no-cache to ensure settings_loader.py and other recent changes are not skipped due to layer caching. Fixes issue where Django continued using local file storage instead of S3.