### PR TITLE
fix(secure-file): ensure correct upload paths by using content_object assignment

### DIFF
--- a/feedit_app/company_requests/views.py
+++ b/feedit_app/company_requests/views.py
@@ -156,8 +156,9 @@ class CreateRequestView(FullyActivatedUserMixin, CreateView):
         file = self.request.FILES.get("verification_document")
         if file:
             SecureFile.objects.create(
-                content_type=ContentType.objects.get_for_model(Request),
-                object_id=self.object.id,
+                # content_type=ContentType.objects.get_for_model(Request),
+                # object_id=self.object.id,
+                content_object=self.object,
                 file=file,
                 uploaded_by=self.request.user,
             )
@@ -398,8 +399,9 @@ class CreateRequestReplyView(FullyActivatedUserMixin, CreateView):
         file = self.request.FILES.get("upload_document")
         if file:
             SecureFile.objects.create(
-                content_type=ContentType.objects.get_for_model(RequestReply),
-                object_id=self.object.id,
+                # content_type=ContentType.objects.get_for_model(RequestReply),
+                # object_id=self.object.id,
+                content_object=self.object,
                 file=file,
                 uploaded_by=self.request.user,
             )

--- a/feedit_app/secure_files/models.py
+++ b/feedit_app/secure_files/models.py
@@ -31,7 +31,7 @@ def upload_to(instance, filename):
     model = instance.content_type.model
     obj = instance.content_object
 
-    if not obj:
+    if not obj or not hasattr(obj, "id") or not obj.id:
         return f"unresolved/{model}/unsaved/{filename}"
 
     # User and company profile pictures


### PR DESCRIPTION
Previously, files attached to requests and request replies were not uploaded to S3 due to missing object context in the upload_to path resolution. This was caused by directly assigning content_type and object_id before the related object was fully available. Replaced with content_object assignment to ensure full context is present during file path generation.

Also added a fallback for unresolved paths to prevent silent failures.